### PR TITLE
Javascript samples - Search Widget with customized GeocodeServer

### DIFF
--- a/web-js/search-widget-with-customized-geocoder-server/README.md
+++ b/web-js/search-widget-with-customized-geocoder-server/README.md
@@ -1,6 +1,6 @@
-#Join stand alone table to feature layer and display data attributes in Data Grid by using the ArcGIS API for JavaScript 
+#Search Widget with custom geocoding service by using ArcGIS API for JavaScript 
 
-This is a sample shows how to use Search Widget (esri/dijit/Search) to perform search on a customized Geocode Server since geocoder widget is going to be deprecated in the future release. 
+This is a sample shows how to use Search Widget (esri/dijit/Search) to perform search on a custom geocoding service since geocoder widget is going to be deprecated in the future release. 
 
 [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/)
 [Search](https://developers.arcgis.com/javascript/jsapi/search-amd.html)
@@ -22,8 +22,8 @@ https://developers.arcgis.com/javascript/jssamples/search_customized.html
 
 ## Features
 
-* Shows how to use search widget to connect with customized geocode server 
-* Contains code showing how to combine search widget with locator to perform the search query on geocode server 
+* Shows how to use search widget to connect with custom geocoding service 
+* Contains code showing how to combine search widget with locator to perform the search query on geocoding service 
 
 NOTE: Feel free to update to this repo!
 

--- a/web-js/search-widget-with-customized-geocoder-server/README.md
+++ b/web-js/search-widget-with-customized-geocoder-server/README.md
@@ -1,0 +1,17 @@
+#Join stand alone table to feature layer and display data attributes in Data Grid by using the ArcGIS API for JavaScript 
+
+This is a sample shows how to use Search Widget (esri/dijit/Search) to perform search on a customized Geocode Server since geocoder widget is going to be deprecated in the future release. 
+
+[ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/)
+[Search](https://developers.arcgis.com/javascript/jsapi/search-amd.html)
+
+## Extended based on the sample 
+Search with customization
+https://developers.arcgis.com/javascript/jssamples/search_customized.html
+
+## Features
+
+* Shows how to use search widget to connect with customized geocode server 
+* Contains code showing how to combine search widget with locator to perform the search query on geocode server 
+
+NOTE: Feel free to update to this repo!

--- a/web-js/search-widget-with-customized-geocoder-server/README.md
+++ b/web-js/search-widget-with-customized-geocoder-server/README.md
@@ -7,7 +7,9 @@ This is a sample shows how to use Search Widget (esri/dijit/Search) to perform s
 
 ## Pay Attention when using Search Widget on GeocodeServer
 If you want to have auto suggestions when input an address for search widget to automatically return close result, there are two requirements need to follow:  
+
 1. GeocodeServer must published from ArcGIS Server 10.3 or later version
+
 2. The server must enabled "Suggest" capability, see the below screenshot
 
 ![Alt text](https://cloud.githubusercontent.com/assets/5265346/8464836/1abf11aa-1ffa-11e5-82d1-74180a21e51b.JPG "Enable "Suggest" capability")
@@ -24,4 +26,5 @@ https://developers.arcgis.com/javascript/jssamples/search_customized.html
 * Contains code showing how to combine search widget with locator to perform the search query on geocode server 
 
 NOTE: Feel free to update to this repo!
-EXPLICIT: This is a demo server and not intended for use for anything other than testing. The demo server within this sample is not intended for use for anything other than testing!
+
+**EXPLICIT: The demo server within this sample is not intended for use for anything other than testing!**

--- a/web-js/search-widget-with-customized-geocoder-server/README.md
+++ b/web-js/search-widget-with-customized-geocoder-server/README.md
@@ -5,7 +5,16 @@ This is a sample shows how to use Search Widget (esri/dijit/Search) to perform s
 [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/)
 [Search](https://developers.arcgis.com/javascript/jsapi/search-amd.html)
 
-## Extended based on the sample 
+## Pay Attention when using Search Widget on GeocodeServer
+If you want to have auto suggestions when input an address for search widget to automatically return close result, there are two requirements need to follow:  
+1. GeocodeServer must published from ArcGIS Server 10.3 or later version
+2. The server must enabled "Suggest" capability, see the below screenshot
+
+![Alt text](https://cloud.githubusercontent.com/assets/5265346/8464836/1abf11aa-1ffa-11e5-82d1-74180a21e51b.JPG "Enable "Suggest" capability")
+
+## Extended based on the sample GeocodeServer is
+published from ArcGIS Server 10.3 or later and must enabled "Suggest"
+capability
 Search with customization
 https://developers.arcgis.com/javascript/jssamples/search_customized.html
 
@@ -15,3 +24,4 @@ https://developers.arcgis.com/javascript/jssamples/search_customized.html
 * Contains code showing how to combine search widget with locator to perform the search query on geocode server 
 
 NOTE: Feel free to update to this repo!
+EXPLICIT: This is a demo server and not intended for use for anything other than testing. The demo server within this sample is not intended for use for anything other than testing!

--- a/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
+++ b/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
@@ -84,27 +84,18 @@
 
       require([
       "esri/map",
-      "esri/layers/FeatureLayer",
       "esri/dijit/Search",
       "esri/tasks/locator",
       "esri/symbols/PictureMarkerSymbol",
       "esri/InfoTemplate",
       "dojo/domReady!"
-      ], function (Map, FeatureLayer, Search, Locator, PictureMarkerSymbol, InfoTemplate) {
+      ], function (Map, Search, Locator, PictureMarkerSymbol, InfoTemplate) {
 
          map = new Map("map", {
             basemap: "dark-gray",
             center: [-122.029133,47.521962], // lon, lat
             zoom: 10
          });
-         //ArcGIS Online feature service showing ecological footprints taken from Global FootPrint Network, 
-         //more information on this can be found http://jsapi.maps.arcgis.com/home/item.html?id=0f4c89208dce44b583d9219d843591c3
-         var layer = new FeatureLayer("http://services.arcgis.com/Ej0PsM5Aw677QF1W/arcgis/rest/services/KingCountySchoolDistricts/FeatureServer/0", {
-            outFields: ["*"],
-            mode: FeatureLayer.MODE_ONDEMAND,
-            opacity: 0.3
-         });
-         map.addLayer(layer);
 
          //Create search widget
          var search = new Search({
@@ -119,8 +110,10 @@
 
          //listen for the load event and set the source properties 
          search.on("load", function () {
+             
             var sources = search.sources; 
             // In order to make suggestion works for GeocodeServer, user need to use ArcGIS 10.3 or later version and enable "Suggest" capability when publishing services, for more information please check our online documentation: https://developers.arcgis.com/javascript/jsapi/search-amd.html#enablesuggestions
+            
             var locator = new Locator("http://arclogistics.arcgisonline.com/arcgis/rest/services/King_County/GeocodeServer");
             sources.push({
                locator: locator,

--- a/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
+++ b/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html dir="ltr">
+<head>
+   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
+   <title>ArcGIS API for JavaScript | Customize Search widget for Geocode Server</title>
+   <link rel="stylesheet" href="http://js.arcgis.com/3.13/dijit/themes/claro/claro.css">
+   <link rel="stylesheet" href="http://js.arcgis.com/3.13/esri/css/esri.css">
+   <style>
+      html,
+      body,
+      #map,
+      .map.container {
+         padding: 0;
+         margin: 0;
+         height: 100%;
+         width: 100%;
+      }
+      #info {
+         top: 2px;
+         color: #444;
+         height: auto;
+         font-family: arial;
+         font-weight: bold;
+         left: 69px;
+         margin: 5px;
+         padding: 10px;
+         position: absolute;
+         width: 260px;
+         z-index: 40;
+         border: solid 1px #003300;
+         border-radius: 4px;
+         background-color: #E5E5E5;
+      }
+      #search {
+         display: block;
+         position: absolute;
+         z-index: 2;
+         top: 85px;
+         left: 74px;
+      }
+      /*Beginning of search box modifications*/
+      .arcgisSearch .searchClear {
+         background-color: #E5E5E5;
+      }
+
+      .arcgisSearch .searchGroup .searchInput,
+      .arcgisSearch .searchBtn,
+      .arcgisSearch .noResultsMenu,
+      .arcgisSearch .suggestionsMenu {
+         border: 1px solid #003300;
+         background-color: #E5E5E5;
+      }
+      .arcgisSearch .noValueText {
+         color: red;
+         font-size: 14px;
+      }
+      /*Beginning of popup modifications*/
+      .esriPopup .titlePane {
+         background-color: #003300;
+         border-bottom: 1px solid #121310;
+         font-weight: bold;
+      }
+      .esriPopup a {
+         color: #DAE896;
+      }
+      .esriPopup .contentPane,
+      .esriPopup .actionsPane,
+      .esriPopup .pointer,
+      .esriPopup .outerPointer {
+         background-color: #B3B3B3;
+      }
+   </style>
+
+   <script>
+      var dojoConfig = {
+         parseOnLoad: true
+      };
+   </script>
+   <script src="http://js.arcgis.com/3.13/"></script>
+
+   <script>
+      var map;
+
+      require([
+      "esri/map",
+      "esri/layers/FeatureLayer",
+      "esri/dijit/Search",
+      "esri/tasks/locator",
+      "esri/symbols/PictureMarkerSymbol",
+      "esri/InfoTemplate",
+      "dojo/domReady!"
+      ], function (Map, FeatureLayer, Search, Locator, PictureMarkerSymbol, InfoTemplate) {
+
+         map = new Map("map", {
+            basemap: "dark-gray",
+            center: [-84.392537,33.760878], // lon, lat
+            zoom: 12
+         });
+         //ArcGIS Online feature service showing ecological footprints taken from Global FootPrint Network, 
+         //more information on this can be found http://jsapi.maps.arcgis.com/home/item.html?id=0f4c89208dce44b583d9219d843591c3
+         var layer = new FeatureLayer("http://services.arcgis.com/Wl7Y1m92PbjtJs5n/arcgis/rest/services/Atlanta_City_GA/FeatureServer/0", {
+            outFields: ["*"]
+         });
+         map.addLayer(layer);
+
+         //Create search widget
+         var search = new Search({
+            enableLabel:false,
+            enableInfoWindow: true,
+            map: map,
+            //passing in empty source array to clear defaults such as 
+            //"All" and the ArcGIS Online World Geocoding service
+            sources: [],
+            zoomScale: 110000
+         }, "search");
+
+         //listen for the load event and set the source properties 
+         search.on("load", function () {
+            var sources = search.sources;
+            var locator = new Locator("http://nwu-win7.esri.com/server/rest/services/AtlantaGeolocator/GeocodeServer");
+            sources.push({
+               locator: locator,
+               singleLineFieldName: "Single Line Input",
+               maxSuggestions: 3,
+               placeholder: "Please type street name",
+               enableLabel: false,
+               exactMatch: false,
+               outFields: ["*"],
+               highlightSymbol: new PictureMarkerSymbol('https://cdn0.iconfinder.com/data/icons/20-flat-icons/128/location-pointer.png',26,33).setOffset(1,1),
+               //Create an InfoTemplate and include three fields
+               infoTemplate: new InfoTemplate("Address Locator", "Address: ${Match_addr}</br>")
+            });
+            //Set the sources above to the search widget
+            search.set("sources", sources);
+         });
+         search.startup();
+      });
+   </script>
+</head>
+
+<body>
+   <div id="search"></div>
+   <div id="info">
+      <div>Using a customized Geocoder Server to find street by using JS "Search Widget"</div>
+   </div>
+   <div id="map"></div>
+</body>
+</html>

--- a/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
+++ b/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
@@ -94,13 +94,15 @@
 
          map = new Map("map", {
             basemap: "dark-gray",
-            center: [-84.392537,33.760878], // lon, lat
-            zoom: 12
+            center: [-122.029133,47.521962], // lon, lat
+            zoom: 10
          });
          //ArcGIS Online feature service showing ecological footprints taken from Global FootPrint Network, 
          //more information on this can be found http://jsapi.maps.arcgis.com/home/item.html?id=0f4c89208dce44b583d9219d843591c3
-         var layer = new FeatureLayer("http://services.arcgis.com/Wl7Y1m92PbjtJs5n/arcgis/rest/services/Atlanta_City_GA/FeatureServer/0", {
-            outFields: ["*"]
+         var layer = new FeatureLayer("http://services.arcgis.com/Ej0PsM5Aw677QF1W/arcgis/rest/services/KingCountySchoolDistricts/FeatureServer/0", {
+            outFields: ["*"],
+            mode: FeatureLayer.MODE_ONDEMAND,
+            opacity: 0.3
          });
          map.addLayer(layer);
 
@@ -112,16 +114,17 @@
             //passing in empty source array to clear defaults such as 
             //"All" and the ArcGIS Online World Geocoding service
             sources: [],
-            zoomScale: 110000
+            zoomScale: 5000000
          }, "search");
 
          //listen for the load event and set the source properties 
          search.on("load", function () {
-            var sources = search.sources;
-            var locator = new Locator("http://nwu-win7.esri.com/server/rest/services/AtlantaGeolocator/GeocodeServer");
+            var sources = search.sources; 
+            // In order to make suggestion works for GeocodeServer, user need to use ArcGIS 10.3 or later version and enable "Suggest" capability when publishing services, for more information please check our online documentation: https://developers.arcgis.com/javascript/jsapi/search-amd.html#enablesuggestions
+            var locator = new Locator("http://arclogistics.arcgisonline.com/arcgis/rest/services/King_County/GeocodeServer");
             sources.push({
                locator: locator,
-               singleLineFieldName: "Single Line Input",
+               singleLineFieldName: "SingleLine",
                maxSuggestions: 3,
                placeholder: "Please type street name",
                enableLabel: false,

--- a/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
+++ b/web-js/search-widget-with-customized-geocoder-server/searchGeocodeServer.html
@@ -94,15 +94,13 @@
 
          map = new Map("map", {
             basemap: "dark-gray",
-            center: [-122.029133,47.521962], // lon, lat
-            zoom: 10
+            center: [-84.392537,33.760878], // lon, lat
+            zoom: 12
          });
          //ArcGIS Online feature service showing ecological footprints taken from Global FootPrint Network, 
          //more information on this can be found http://jsapi.maps.arcgis.com/home/item.html?id=0f4c89208dce44b583d9219d843591c3
-         var layer = new FeatureLayer("http://services.arcgis.com/Ej0PsM5Aw677QF1W/arcgis/rest/services/KingCountySchoolDistricts/FeatureServer/0", {
-            outFields: ["*"],
-            mode: FeatureLayer.MODE_ONDEMAND,
-            opacity: 0.3
+         var layer = new FeatureLayer("http://services.arcgis.com/Wl7Y1m92PbjtJs5n/arcgis/rest/services/Atlanta_City_GA/FeatureServer/0", {
+            outFields: ["*"]
          });
          map.addLayer(layer);
 
@@ -114,17 +112,16 @@
             //passing in empty source array to clear defaults such as 
             //"All" and the ArcGIS Online World Geocoding service
             sources: [],
-            zoomScale: 5000000
+            zoomScale: 110000
          }, "search");
 
          //listen for the load event and set the source properties 
          search.on("load", function () {
-            var sources = search.sources; 
-            // In order to make suggestion works for GeocodeServer, user need to use ArcGIS 10.3 or later version and enable "Suggest" capability when publishing services, for more information please check our online documentation: https://developers.arcgis.com/javascript/jsapi/search-amd.html#enablesuggestions
-            var locator = new Locator("http://arclogistics.arcgisonline.com/arcgis/rest/services/King_County/GeocodeServer");
+            var sources = search.sources;
+            var locator = new Locator("http://nwu-win7.esri.com/server/rest/services/AtlantaGeolocator/GeocodeServer");
             sources.push({
                locator: locator,
-               singleLineFieldName: "SingleLine",
+               singleLineFieldName: "Single Line Input",
                maxSuggestions: 3,
                placeholder: "Please type street name",
                enableLabel: false,


### PR DESCRIPTION
This is a sample shows how to use Search Widget to perform search on
GeocodeServer since geocoder widget is going to be deprecated.