### PR TITLE
Change Field Alias for cpp

### DIFF
--- a/arcobjects-c++/change-field-alias/ChangeFieldAlias.cpp
+++ b/arcobjects-c++/change-field-alias/ChangeFieldAlias.cpp
@@ -1,0 +1,69 @@
+// ChangeFieldAlias.cpp : Defines the entry point for the console application.
+//
+
+#include "stdafx.h"
+#include "LicenseUtilities.h"
+#include <ArcSDK.h>
+
+int _tmain(int argc, _TCHAR* argv[])
+{
+	if (!InitializeApp())
+	{
+		AoExit(0);
+	}
+
+	try{
+
+		CONST CComBSTR MapDocLocation = "C:\\Users\\alex7370\\Desktop\\mxdFont.mxd";
+		CONST CComBSTR MapDocPassword = "";
+		CONST IMapDocumentPtr MapDoc(CLSID_MapDocument);
+		CONST CComBSTR expectedAlias = "Int";
+		CONST CComBSTR desiredAlias = "INT";
+
+		std::cerr << "Loading the map document..." << std::endl;
+		MapDoc->Open(MapDocLocation, MapDocPassword);
+		std::cerr << "Finding the correct layer..." << std::endl;
+		IActiveViewPtr activeView;
+		MapDoc->get_ActiveView(&activeView);
+		IMapPtr map;
+		activeView->get_FocusMap(&map);
+		ILayerPtr layer;
+		map->get_Layer(0, &layer);
+		std::cerr << "Layer found!" << std::endl;
+		std::cerr << "Looking for fields in layer..." << std::endl << "Updating as necessary..." << std::endl;
+		ILayerFieldsPtr layerFields = layer;
+		long fieldCount;
+		layerFields->get_FieldCount(&fieldCount);
+		for (int i = 0; i < fieldCount; i++)
+		{
+			IFieldInfoPtr fieldInfo;
+			layerFields->get_FieldInfo(i, &fieldInfo);
+			CComBSTR fieldAlias;
+			fieldInfo->get_Alias(&fieldAlias);
+			if (fieldAlias == expectedAlias)
+			{
+				fieldInfo->put_Alias(desiredAlias);
+				std::cerr << "Replaced!" << std::endl;
+			}
+		}
+		std::cerr << "Attempting to save...";
+
+		MapDoc->Save(VARIANT_FALSE, VARIANT_TRUE);
+
+		std::cerr << "Saved!" << std::endl << "Done!" << std::endl;
+
+	}
+	catch (_com_error e)
+	{
+		TCHAR str[255];
+		BSTR bstr = BSTR(e.Description());
+		if (bstr)
+			wsprintf(str, _T("Known Error : \n %ls"), bstr);
+		else
+			wsprintf(str, _T("Unknown Error..\n"));
+		return E_FAIL;
+	}
+	AoExit(0);
+
+	return 0;
+}

--- a/arcobjects-c++/change-field-alias/ReadMe.md
+++ b/arcobjects-c++/change-field-alias/ReadMe.md
@@ -1,0 +1,16 @@
+#Change Layer Fieldname Alias
+## Use case
+You want to change fieldname alias to match that of your new convention for all your layers.  This will iterate through all fields in the first layer in the MXD and update field alias as long as they match a certain condition.
+
+##Instructions
+* On line 17 select the map document in which you want to change the fieldname alias in your specific map document.
+*  Lines 37 through 47 look for field names that match a criteria and replace the alias with an updated one.
+
+##Things to know:
+* [Interface ILayerFields](http://resources.arcgis.com/en/help/arcobjects-cpp/componenthelp/index.html#//00050000073z000000)
+* [Interface IFieldInfo](http://resources.arcgis.com/en/help/arcobjects-cpp/componenthelp/index.html#//000s00000356000000)
+* [Interface ILayer](http://resources.arcgis.com/en/help/arcobjects-cpp/componenthelp/index.html#//0005000006z1000000)
+
+######Authors
+* Doug Carroll with [original script](https://github.com/Esri/developer-support/blob/master/arcobjects-net/change-layer-fieldname-alias/ChangeFieldAlias.cs)
+* Alexander Nohe


### PR DESCRIPTION
This allows users to change a field alias and matches the .NET and Java versions of this sample providing consistency for ArcObjects.

:octocat: