### PR TITLE
added links in contributor help to 'github guides' 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,12 @@ Feel free to file an [issue](https://github.com/Esri/developer-support/issues/ne
 
 ### Resources
 
+* Official [GitHub Guides](https://guides.github.com/)
 * [Contributing](https://guides.github.com/activities/contributing-to-open-source/) to Open Source projects
 * Learning [Git](https://github.com/Esri/developer-support/wiki/Resources-To-Learn-Git)
+* Twitter [Infographic](https://twitter.com/cthydng/status/575483540202106880?s=09)
+* [GitHub Desktop](https://desktop.github.com/)
+* [SourceTree](https://www.atlassian.com/software/sourcetree/overview/)
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ Feel free to file an [issue](https://github.com/Esri/developer-support/issues/ne
 * [Contributing](https://guides.github.com/activities/contributing-to-open-source/) to Open Source projects
 * Learning [Git](https://github.com/Esri/developer-support/wiki/Resources-To-Learn-Git)
 * Twitter [Infographic](https://twitter.com/cthydng/status/575483540202106880?s=09)
-* [GitHub Desktop](https://desktop.github.com/)
-* [SourceTree](https://www.atlassian.com/software/sourcetree/overview/)
+* App: [GitHub Desktop](https://desktop.github.com/)
+* App: [SourceTree](https://www.atlassian.com/software/sourcetree/overview/)
 
 
 


### PR DESCRIPTION
referencing #48

Updated contributing doc to include links to GitHub best practices, a Twitter infographic, and two apps to use with GitHub.