### PR TITLE
Prints URL to replica

### DIFF
--- a/python/general-python/create-replica-and-download/createReplicaAndDownload.py
+++ b/python/general-python/create-replica-and-download/createReplicaAndDownload.py
@@ -1,17 +1,16 @@
-#Downloads a replica created asynchronously
-#Resources: https://developers.arcgis.com/rest/analysis/api-reference/programmatically-accessing-analysis-services.htm
 import urllib, urllib2, json, time, os
+
+username = "username"                                             #CHANGE
+password = "password"                                             #CHANGE
+replicaURL = "feature service url/FeatureServer/createReplica"    #CHANGE
+replicaLayers = [0]                                               #CHANGE
+replicaName = "replicaTest"                                       #CHANGE
 
 def sendRequest(request):
     response = urllib2.urlopen(request)
     readResponse = response.read()
     jsonResponse = json.loads(readResponse)
     return jsonResponse
-
-username = "username"                                             #CHANGE
-password = "password"                                             #CHANGE
-downloads = r"location of downloads folder"                       #CHANGE
-replicaURL = "feature service url/FeatureServer/createReplica"    #CHANGE
 
 print("Generating token")
 url = "https://arcgis.com/sharing/rest/generateToken"
@@ -25,8 +24,8 @@ token = jsonResponse['token']
 
 print("Creating the replica")
 data = {'f' : 'json',
-    'replicaName' : 'Nov20Test',
-    'layers' : [0,1],
+    'replicaName' : replicaName,
+    'layers' : replicaLayers,
     'returnAttachments' : 'true',
     'returnAttachmentsDatabyURL' : 'false',
     'syncModel' : 'none',
@@ -47,9 +46,12 @@ while not jsonResponse.get("status") == "Completed":
     request = urllib2.Request(url)
     jsonResponse = sendRequest(request)
 
-print("Downloading the replica")
-url = jsonResponse['resultUrl']
-f = urllib2.urlopen(url)
-with open(downloads + "\\" + os.path.basename(url), "wb") as local_file:
-    local_file.write(f.read())
+userDownloads = os.environ['USERPROFILE'] + "\\Downloads"
 
+print("Downloading the replica. In case this fails note that the replica URL is: \n")
+url = jsonResponse['resultUrl']
+print("{0}?token={1}".format(url, token))
+f = urllib2.urlopen(url)
+with open(userDownloads + "\\" + os.path.basename(url), "wb") as local_file:
+    local_file.write(f.read())
+print("\n Finished!")

--- a/python/general-python/create-replica-and-download/createReplicaAndDownload.py
+++ b/python/general-python/create-replica-and-download/createReplicaAndDownload.py
@@ -49,9 +49,10 @@ while not jsonResponse.get("status") == "Completed":
 userDownloads = os.environ['USERPROFILE'] + "\\Downloads"
 
 print("Downloading the replica. In case this fails note that the replica URL is: \n")
-url = jsonResponse['resultUrl']
-print("{0}?token={1}".format(url, token))
+jres = jsonResponse['resultUrl']
+url = "{0}?token={1}".format(jres, token)
+print(url)
 f = urllib2.urlopen(url)
-with open(userDownloads + "\\" + os.path.basename(url), "wb") as local_file:
+with open(userDownloads + "\\" + os.path.basename(jres), "wb") as local_file:
     local_file.write(f.read())
 print("\n Finished!")

--- a/python/general-python/create-replica-and-download/readme.md
+++ b/python/general-python/create-replica-and-download/readme.md
@@ -1,12 +1,13 @@
 #Create Replica and Download Usage Notes
-Create and download a file geodatabase replica from a feature service hosted on ArcGIS Online. To get this script running, change these four lines of code:
+Create and download a file geodatabase replica from a feature service hosted on ArcGIS Online. To get this script running, change these lines of code:
 ```python
 username = "username"                                             #CHANGE
 password = "password"                                             #CHANGE
-downloads = r"location of downloads folder"                       #CHANGE
 replicaURL = "feature service url/FeatureServer/createReplica"    #CHANGE
+replicaLayers = [0]                                               #CHANGE
+replicaName = "replicaTest"                                       #CHANGE
 ```
-The script assumes the replica is created asynchronously. After the create replica request is submitted, the server is pinged every five seconds until the zipped file is fully populated, at which point the zipped file is downloaded.
+The script assumes the replica is created asynchronously. After the create replica request is submitted, the server is pinged every five seconds until the zipped file is fully populated, at which point the zipped file is downloaded in the Downloads folder.
 ##Additional Resources
 
 Generate Token


### PR DESCRIPTION
Prints URL to replica, including token. This may be helpful if an empty zip is downloaded. In this case, copy paste the replica url into a browser and see if the downloaded zip is still empty.

Also replica now automatically downloads to the current user's Downloads folder. No longer need to specify the downloads folder.

Would appreciate if script is tested before merging. 

https://github.com/Esri/developer-support/issues/207