### PR TITLE
Added example that reads information from local file geodatabases

### DIFF
--- a/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
@@ -46,7 +46,16 @@ namespace FGDB_Crawler_CSVGen
                         printCSVHeader(outfile);
                         exploreFGDB(rootPath, outfile);
                         break;
+                    case "-P": // Path to a File GeoDatabase
+                        testFGDBPath(rootPath);
+                        Console.WriteLine("Processing... please wait.");
+                        printCSVHeader(outfile);
+                        exploreFGDB(rootPath, outfile);
+                        break;
                     case "-r": // Root directory that contains File GeoDatabases
+                        exploreRootDirectory(rootPath, outfile);
+                        break;
+                    case "-R": // Root directory that contains File GeoDatabases
                         exploreRootDirectory(rootPath, outfile);
                         break;
                     default:

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
@@ -1,0 +1,236 @@
+using System;
+using ESRI.ArcGIS.Geodatabase;
+using ESRI.ArcGIS.esriSystem;
+using System.Runtime.InteropServices;
+using ESRI.ArcGIS.DataSourcesGDB;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.Diagnostics;
+
+namespace FGDB_Crawler_CSVGen
+{
+    class Program
+    {
+        [STAThread()]
+        static void Main(string[] args)
+        {
+            // Don't show the "program stopped working" popup if a file/path cannot be opened
+            AppDomain.CurrentDomain.UnhandledException += (sender, eargs) =>
+            {
+                Console.Error.WriteLine("Unhandled exception: " + eargs.ExceptionObject);
+                Environment.Exit(1);
+            };
+
+            // The user must specify the root path to be explored (i.e. a path containing File GeoDatabases (*.gdb)
+            // as well as an output csv file
+            if (args.Length != 2)
+            {
+                Console.WriteLine("Usage: .\\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv");
+                Console.WriteLine("Aborting.");
+                System.Environment.Exit(1);
+            }
+            else
+            {
+                // Bind this ArcObjects application to this machine's ArcGIS license
+                ESRI.ArcGIS.RuntimeManager.Bind(ESRI.ArcGIS.ProductCode.Desktop);
+                // Fetch the License
+                ESRI.ArcGIS.esriSystem.IAoInitialize ao = new ESRI.ArcGIS.esriSystem.AoInitialize();
+                esriLicenseStatus status = ao.Initialize(ESRI.ArcGIS.esriSystem.esriLicenseProductCode.esriLicenseProductCodeStandard);
+
+                // Print all *.gdb in the path
+                {
+                    string rootPath = args[0]; // Target path is the first argument of the console application
+                    string outfile = args[1]; // Output CSV file is the second argument
+
+                    string[] folders = null;
+                    try
+                    {
+                        folders = Directory.GetDirectories(rootPath);
+                    }catch (Exception exc)
+                    {
+                        Console.WriteLine("Error: Could not find the specified path: \"" + rootPath + "\"");
+                        Console.WriteLine(exc.InnerException.Message);
+                        System.Environment.Exit(1);
+                    }
+                    Console.WriteLine();
+                    Console.WriteLine("Processing... please wait.");
+                    // Print the CSV Header
+                    printCSVHeader(outfile);
+
+                    foreach (string folder in folders) // For each folder in the root path
+                    {
+                        try
+                        {
+                            string fileExt = Path.GetExtension(folder); // Get this folder's file extension
+                            if (fileExt != ".gdb") continue; // If the folder is not a File GeoDatabase, skip it
+                            exploreFGDB(folder, outfile); // Process the File GeoDatabase
+                        }
+                        catch (Exception)
+                        {
+                            continue;
+                        }
+
+                    }
+                }
+                Console.WriteLine("Done Processing.");
+                System.Environment.Exit(0);
+            }
+        }
+
+        // Print the CSV Header to the output CSV file 'outfile'
+        private static void printCSVHeader(string outfile)
+        {
+            string csvHeader = "Full Path,Local Path,Name,Category,Type,Full Name,Last Accessed,Time Created,Date Modified,File Size on Disk";
+            csvHeader += Environment.NewLine;
+            System.IO.File.WriteAllText(outfile, csvHeader);
+        }
+
+
+        // Append string 'str' to output CSV file 'filename'
+        private static void appendToFile(string filename, string str)
+        {
+            using (System.IO.StreamWriter file =
+                new System.IO.StreamWriter(filename, true))
+            {
+                file.Write(str);
+                file.Flush();
+                file.Close();
+            }
+        }
+
+        // Explore the File GeoDatabase specified in fgdbPath, print information about its contents to the CSV file 'outfile'
+        private static void exploreFGDB(string fgdbPath, string outfile)
+        {
+            IWorkspaceFactory workspaceFactory = (IWorkspaceFactory)Activator.CreateInstance(typeof(FileGDBWorkspaceFactoryClass));
+
+            IFeatureWorkspace ifw = (IFeatureWorkspace)workspaceFactory.OpenFromFile(fgdbPath, 0);
+            if (ifw == null) return;
+
+            IWorkspace fw = workspaceFactory.OpenFromFile(fgdbPath, 0);
+
+            IEnumDataset datasets = fw.Datasets[esriDatasetType.esriDTAny];
+
+            processIEnumDataset(outfile, ifw, datasets, 0, "", fgdbPath);
+        }
+
+        // Recursively explore an IEnumDataset
+        private static void processIEnumDataset(string outfile, IFeatureWorkspace ifw, IEnumDataset datasets, int depth, string localPath, string fgdbPath)
+        {
+            if (datasets == null) return;
+
+            datasets.Reset();
+            IDataset dataset;
+
+            // Iterate through the entire dataset
+            while (null != (dataset = datasets.Next()))
+            {
+                // Process the current dataset
+                processIDataset(outfile, ifw, dataset, depth, localPath, fgdbPath);
+            }
+        }
+
+        private static void processIDataset(string outfile, IFeatureWorkspace ifw, IDataset dataset, int depth, string localPath, string fgdbPath)
+        {
+            string newLocalPath = localPath + "/" + dataset.Name.ToString();
+
+            // Print information about this dataset to the CSV
+            appendToFile(outfile, fgdbPath + ",");
+            appendToFile(outfile, newLocalPath + ",");
+            appendToFile(outfile, dataset.Name.ToString() + ",");
+            appendToFile(outfile, dataset.Category.ToString() + ",");
+            appendToFile(outfile, dataset.Type.ToString() + ",");
+            appendToFile(outfile, dataset.FullName.ToString() + ",");
+
+            printIDatasetSizeAndTime(outfile, ifw, dataset.Name.ToString(), depth);
+
+            // If this dataset has children, iterate through its children
+            IEnumDataset children = dataset.Subsets;
+            processIEnumDataset(outfile, ifw, children, depth + 1, newLocalPath, fgdbPath);
+        }
+
+        // Print the IDataset's size and time. If it doesn't have any, print a message and then return
+        private static void printIDatasetSizeAndTime(string outfile, IFeatureWorkspace ifw, string name, int depth)
+        {
+
+            try
+            {
+                var pTable = ifw.OpenTable(name);
+                if (pTable == null) return;
+
+                var pDFS = (IDatasetFileStat)pTable;
+                if (pDFS == null) return;
+
+                // Date Modified
+                var unixtimestmap = pDFS.StatTime[esriDatasetFileStatTimeMode.esriDatasetFileStatTimeLastModification];
+                appendToFile(outfile, unixTimeStampToString(unixtimestmap) + ",");
+
+                // Time Created
+                unixtimestmap = pDFS.StatTime[esriDatasetFileStatTimeMode.esriDatasetFileStatTimeCreation];
+                appendToFile(outfile, unixTimeStampToString(unixtimestmap) + ",");
+
+                // Last Accessed
+                unixtimestmap = pDFS.StatTime[esriDatasetFileStatTimeMode.esriDatasetFileStatTimeLastAccess];
+                appendToFile(outfile, unixTimeStampToString(unixtimestmap) + ",");
+
+                // File Size on Disk
+                string sizeBytes = pDFS.StatSize.ToString();
+                appendToFile(outfile, convertBytes(sizeBytes) + Environment.NewLine);
+            }
+            catch (COMException e)
+            {
+                // Can't open table ; can't get info about date modified / time created / last accessed / file size on disk
+                // so fields will be left blank in the CSV
+                appendToFile(outfile, ",,," + Environment.NewLine);
+                return;
+            }
+        }
+        
+        // Convert a Unix timestaop to a readable string
+        private static string unixTimeStampToString(int timestamp)
+        {
+            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dtResult = dt.AddSeconds(Convert.ToDouble(timestamp));
+            return dtResult.ToString();
+        }
+
+        // Given a number of bytes, return a readable string to 2 decimal places
+        private static string convertBytes(string numBytes)
+        {
+            double bytes = double.Parse(numBytes);
+
+            string result;
+
+            if (bytes >= 1099511627776)
+            {
+                double terabytes = bytes / 1099511627776;
+                result = Math.Round(Convert.ToDecimal(terabytes), 2).ToString() + " TB";
+            }
+            else if (bytes >= 1073741824)
+            {
+                double gigabytes = bytes / 1073741824;
+                result = Math.Round(Convert.ToDecimal(gigabytes), 2).ToString() + " GB";
+            }
+            else if (bytes >= 1048576)
+            {
+                double megabytes = bytes / 1048576;
+                result = Math.Round(Convert.ToDecimal(megabytes), 2).ToString() + " MB";
+            }
+            else if (bytes >= 1024)
+            {
+                double kilobytes = bytes / 1024;
+                result = Math.Round(Convert.ToDecimal(kilobytes), 2).ToString() + " KB";
+            }
+            else
+            {
+                result = Math.Round(Convert.ToDecimal(bytes), 2).ToString() + " bytes";
+            }
+            return result;
+        }
+    }
+}

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/Program.cs
@@ -36,6 +36,7 @@ namespace FGDB_Crawler_CSVGen
                 string option = args[0];
                 string rootPath = args[1]; // Target path is the first argument of the console application
                 string outfile = args[2]; // Output CSV file is the second argument
+                outfile = toCSVPath(outfile);
 
                 switch (option)
                 {
@@ -57,6 +58,16 @@ namespace FGDB_Crawler_CSVGen
                 System.Environment.Exit(0);
             }
         }
+
+        // If there is no '.csv' file extension, then append '.csv' to the end of the path.
+        // Otherwise, return the original string
+        private static string toCSVPath(string path)
+        {
+            string fileExt = Path.GetExtension(path); // Get this folder's file extension
+            if (fileExt != ".csv") return path + ".csv";
+            else return path;
+        }
+
         private static void testFGDBPath(string path)
         {
             string fileExt = Path.GetExtension(path); // Get this folder's file extension

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,8 +1,20 @@
 # Usage:
 
-    .\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv
+This program is a console application that uses ArcObjects. It can be called from the command line in two ways:
 
-This program will take a folder 'targetPath' that contains file geodatabases (\*.gdbs) and generates a CSV file 'outputFile.csv' that contains information about various data contained in the file geodatabases. Non-file-geodatabase (files without a .gdb file extension) will be skipped.
+### 1.) Specifying a folder that contains File GeoDatabases:
+
+    .\FGDB-Crawler-CSVGen.exe -r C:\directorythatcontainsfgdbs outputFile.csv
+
+If the '-r' option is specified, program will take a folder 'directorythatcontainsfgdbs' that contains file geodatabases (\*.gdbs) and generates a CSV file 'outputFile.csv' that contains information about various data contained in the file geodatabases. Non-file-geodatabase (files without a .gdb file extension) will be skipped.
+
+### 2.) Specifying a path to a specific File GeoDatabase:
+
+    .\FGDB-Crawler-CSVGen.exe -p C:\filegeodatabase.gdb outputFile.csv
+
+If the '-p' option is specified, the program will take 'filegeodatabase.gdb' and generate a CSV file 'outputFile.csv' that contains information about that specific file geodatabase.
+
+# What is in the output:
 
 The output CSV file contains information such as:
 * The paths of the .gdb folders found

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,6 +1,6 @@
 # Usage:
 
-.\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv
+**.\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv**
 
 This program will take a folder 'targetPath' that contains file geodatabases (\*.gdbs) and generates a CSV file 'outputFile.csv' that contains information about various data contained in the file geodatabases. Non-file-geodatabase (files without a .gdb file extension) will be skipped.
 

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -14,7 +14,9 @@ If the '-r' option is specified, program will take a folder 'directorythatcontai
 
 If the '-p' option is specified, the program will take 'filegeodatabase.gdb' and generate a CSV file 'outputFile.csv' that contains information about that specific file geodatabase.
 
-# What is in the output:
+# About the .csv output:
+
+Regardless of whether or not the '.csv' is ommitted from the output file (third argument) when the program is called from the command line, the output that is generated will have the '.csv' file extension.
 
 The output CSV file contains information such as:
 * The paths of the .gdb folders found

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,0 +1,11 @@
+# Usage:
+
+.\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv
+
+This program will take a folder 'targetPath' that contains file geodatabases (\*.gdbs) and generates a CSV file 'outputFile.csv' that contains information about various data contained in the file geodatabases. Non-file-geodatabase (files without a .gdb file extension) will be skipped.
+
+The output CSV file contains information such as:
+* The paths of the .gdb folders found
+* What is contained in the .gdb folder (and their subsets/children)
+* What types are they (File Geodatabase Feature Class, File Geodatabase Topology etc.), and where they are located in the .gdb folder
+* If possible to retrieve, what are the creation times, last accessed times, dates modified, and file sizes

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,6 +1,6 @@
 # Usage:
 
-**.\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv**
+    .\FGDB-Crawler-CSVGen.exe targetPath outputFile.csv
 
 This program will take a folder 'targetPath' that contains file geodatabases (\*.gdbs) and generates a CSV file 'outputFile.csv' that contains information about various data contained in the file geodatabases. Non-file-geodatabase (files without a .gdb file extension) will be skipped.
 

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,6 +1,6 @@
 # Usage:
 
-This program is a console application that uses ArcObjects. It can be called from the command line in two ways **Note: Either the -p or the -r option MUST be specified**:
+This program is a console application that uses ArcObjects. It can be called from the command line in two ways **(Note: Either the -p or the -r option MUST be specified)**:
 
 ### 1.) Specifying a folder that contains File GeoDatabases:
 

--- a/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
+++ b/arcobjects-net/explore-fgdbs-and-generate-csv/README.md
@@ -1,6 +1,6 @@
 # Usage:
 
-This program is a console application that uses ArcObjects. It can be called from the command line in two ways:
+This program is a console application that uses ArcObjects. It can be called from the command line in two ways **Note: Either the -p or the -r option MUST be specified**:
 
 ### 1.) Specifying a folder that contains File GeoDatabases:
 


### PR DESCRIPTION
I created a sample console application that extends ArcObjects in C#. This sample can read from local file geodatabases, and generates a CSV containing information about items contained in those file geodatabases (timestamps, file sizes, categories, paths, hierarchy information)

Usage details and more information is included in the README