### PR TITLE
Removed semicolon in arcpy publishing fs from fgdb script.

### DIFF
--- a/python/arcpy-python/publish-fs-to-arcgis-online/create_publish_mxd_with_fgdb_layers_as_hosted_service.py
+++ b/python/arcpy-python/publish-fs-to-arcgis-online/create_publish_mxd_with_fgdb_layers_as_hosted_service.py
@@ -78,7 +78,7 @@ def createDocumentWithFileGeodatabaseLayers(name):
     doc = os.path.join(mxd_path,mxdName)
     message_doc = '{} {}'.format("Current mxd path is: ", doc)
     print message_doc
-    mxd.saveACopy(doc);
+    mxd.saveACopy(doc)
     publishMXDDocumentAsHostedFeatureService(doc, name)
     del doc
     del mxd


### PR DESCRIPTION
In create_publish_mxd_with_fgbd_layers_as_hosted_service.py under arcpy scripts.