### PR TITLE
New app for toggling between 2D map and 3D scene using Map Components in ArcGIS Maps SDK for JavaScript

### DIFF
--- a/maps-sdk/javascript-maps-sdk/map-components-view-toggle/README.md
+++ b/maps-sdk/javascript-maps-sdk/map-components-view-toggle/README.md
@@ -1,0 +1,32 @@
+# Overview
+This project demonstrates how to toggle between a 2D map and a 3D scene using the ArcGIS Maps SDK for JavaScript. The application includes a simple HTML page with a button that allows users to switch between the two views.
+
+## Files
+- **index.html**: The main HTML file containing the structure and logic for the map and scene toggle functionality.
+
+## Dependencies
+- ArcGIS Maps SDK for JavaScript
+- Calcite Components
+- ArcGIS Map Components
+
+## How It Works
+
+### HTML Structure
+- The HTML file includes two main components: an `<arcgis-map>` element for the 2D map and an `<arcgis-scene>` element for the 3D scene.
+- A `<calcite-button>` element is used to toggle between the map and scene views.
+
+### CSS Styling
+- The CSS ensures that the map and scene components fill the entire browser window.
+- The toggle button is styled to be positioned at the top-left corner of the viewport.
+
+### JavaScript Logic
+- The JavaScript code initializes the state by displaying the map and hiding the scene.
+- An event listener is added to the toggle button to switch between the map and scene views when clicked.
+- The button's class is updated to reflect the current view (either "2D" or "3D").
+
+## Usage
+1. Open `index.html` in a web browser.
+2. Click the "Toggle View" button to switch between the 2D map and the 3D scene.
+
+## Conclusion
+This project provides a simple example of how to use the ArcGIS Maps SDK for JavaScript to create an interactive map and scene toggle functionality. It can be extended and customized further based on specific requirements.

--- a/maps-sdk/javascript-maps-sdk/map-components-view-toggle/index.html
+++ b/maps-sdk/javascript-maps-sdk/map-components-view-toggle/index.html
@@ -1,0 +1,92 @@
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
+  <title>Map Components</title>
+
+  <!-- Load required JS API stylesheets -->
+  <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
+
+  <!-- Load the ArcGIS JS API -->
+  <script src="https://js.arcgis.com/4.32"></script>
+
+  <!-- Load map components -->
+  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+  <style>
+    /* Note: these CSS settings cause the map to fill the browser window */
+    html,
+    body {
+      margin: 0;
+    }
+
+    /* Container for the map and scene components */
+    #viewDiv {
+      display: block;
+      height: 100vh;
+      position: relative;
+    }
+
+    /* Style for the map and scene components to occupy full viewport */
+    #map,
+    #scene {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Style for the toggle button */
+    #tv {
+      display: block;
+      position: absolute;
+      z-index: 2;
+      top: 10px;
+      left: 10px;
+      --calcite-button-background-color: purple;
+    }
+  </style>
+</head>
+
+<body>
+  <!-- Container for the map and scene components -->
+  <div id="viewDiv">
+    <!-- ArcGIS map component -->
+    <arcgis-map id="map" item-id="05e015c5f0314db9a487a9b46cb37eca"></arcgis-map>
+    <!-- ArcGIS scene component -->
+    <arcgis-scene id="scene" basemap="satellite" ground="world-elevation" camera-position="12.3808, 46.3959, 4400" camera-tilt="75" camera-heading="300">
+    </arcgis-scene>
+    <!-- Toggle button to switch between map and scene -->
+    <calcite-button id="tv" class="2D">Toggle View</calcite-button>
+  </div>
+
+  <script>
+    // Get references to the button, map, and scene elements
+    let button = document.getElementById("tv");
+    let map = document.getElementById("map");
+    let scene = document.getElementById("scene");
+    // Set initial state: show map and hide scene
+    map.style.display = "block";
+    scene.style.display = "none";
+    // Add click event listener to the button to toggle views
+    button.addEventListener("click", () => {
+      if (button.classList.contains("2D")) {
+        button.classList.remove("2D");
+        button.classList.add("3D");
+        button.style.setProperty('--calcite-button-background-color', 'green');
+        map.style.display = "none";
+        scene.style.display = "block";
+      } else {
+        button.classList.remove("3D");
+        button.classList.add("2D");
+        button.style.setProperty('--calcite-button-background-color', 'purple');
+        scene.style.display = "none";
+        map.style.display = "block";
+      }
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
This pull request introduces a new application that demonstrates how to toggle between a 2D map and a 3D scene using the new Map components functionality of ArcGIS Maps SDK for JavaScript.

The application demonstrates the following:
- How to configure Map components using CDN
- How to add the <arcgis-map> and <arcgis-scene> Map components and configure them with an item-id or with a basic configuration
- How to style the Map components as well as Calcite components with CSS and JS
- JS logic to create a toggle button and use the click event to:
   1. Switch between the map and scene views
   2. Change properties of Calcite components

It can be extended and customized further based on specific requirements. For example, the Map and Scene components always remain accessible even while hidden, which can be used to synchronize the viewport in the background.