### PR TITLE
Adding 3 new samples

### DIFF
--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
@@ -15,10 +15,10 @@ This sample is a modification of an [older sample](https://github.com/Esri/devel
 1. Query the layer to be buffered. Add the result geometries and attributes (distances) to two arrays respectively. The query can be either server-side or client-side.
 
 ```javascript
-        result.features.forEach((feature) => {
-          geometries.push(feature.geometry);
-          distances.push(feature.attributes.pop2000 / 10000);
-        });
+result.features.forEach((feature) => {
+  geometries.push(feature.geometry);
+  distances.push(feature.attributes.pop2000 / 10000);
+});
 ```
 
 2. Verify that geodesicBufferOperator.isLoaded() returns true. If not, load it.

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
@@ -4,9 +4,9 @@
 
 This sample shows how to use an attribute value as the distance when generating buffers.
 
-This sample is a modification of an [older sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/buffer-based-on-attributes). The modifications includes:
+This sample is a modification of an [older sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/buffer-based-on-attributes). These modifications include:
 - Migration from version 4.17 to 4.32
-- Implementation of [Calcite components](https://developers.arcgis.com/calcite-design-system/components/) and [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
+- Implementation of [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
 - [Module loading via CDN](https://developers.arcgis.com/javascript/latest/get-started-cdn/#module-loading-via-cdn)
 - Replacing the deprecated geometryEngine classes with [geometry operators](https://developers.arcgis.com/javascript/latest/spatial-analysis/intro-geometry-operators/)
 
@@ -46,7 +46,6 @@ var buffer = geodesicBufferOperator.executeMany(
 
 - [geometryEngine.geodesicBuffer()](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-operators-geodesicBufferOperator.html#executeMany)
 - [Query a feature layer](https://developers.arcgis.com/javascript/latest/tutorials/query-a-feature-layer-sql/)
-- [Sample Code: GeometryEngine - geodesic buffers](https://developers.arcgis.com/javascript/latest/sample-code/ge-geodesicbuffer/)
 
 ## Live Samples
 

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
@@ -44,7 +44,7 @@ var buffer = geodesicBufferOperator.executeMany(
 
 ## Related Documentation
 
-- [geometryEngine.geodesicBuffer()](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-operators-geodesicBufferOperator.html#executeMany)
+- [geodesicBufferOperator.executeMany()](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-operators-geodesicBufferOperator.html#executeMany)
 - [Query a feature layer](https://developers.arcgis.com/javascript/latest/tutorials/query-a-feature-layer-sql/)
 
 ## Live Samples

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
@@ -1,0 +1,54 @@
+# Create Buffer Based on Attributes
+
+## About
+
+This sample shows how to use an attribute value as the distance when generating buffers.
+
+This sample is a modification of an [older sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/buffer-based-on-attributes). The modifications includes:
+- Migration from version 4.17 to 4.32
+- Implementation of [Calcite components](https://developers.arcgis.com/calcite-design-system/components/) and [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
+- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/get-started-cdn/#module-loading-via-cdn)
+- Replacing the deprecated geometryEngine classes with [geometry operators](https://developers.arcgis.com/javascript/latest/spatial-analysis/intro-geometry-operators/)
+
+## How It Works
+
+1. Query the layer to be buffered. Add the result geometries and attributes (distances) to two arrays respectively. The query can be either server-side or client-side.
+
+```javascript
+        result.features.forEach((feature) => {
+          geometries.push(feature.geometry);
+          distances.push(feature.attributes.pop2000 / 10000);
+        });
+```
+
+2. Verify that geodesicBufferOperator.isLoaded() returns true. If not, load it.
+
+```javascript
+if (!geodesicBufferOperator.isLoaded()) {
+  await geodesicBufferOperator.load();
+}
+```
+
+3. Pass the geometries, distances, and other parameters into the geodesicBufferOperator.executeMany() method, which will return the result buffers as an array of Polygon. 
+
+```javascript
+var buffer = geodesicBufferOperator.executeMany(
+  geometries,
+  distances,
+  {
+    unit: "kilometers",
+    union: true
+  }
+);
+```
+
+## Related Documentation
+
+- [geometryEngine.geodesicBuffer()](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-operators-geodesicBufferOperator.html#executeMany)
+- [Query a feature layer](https://developers.arcgis.com/javascript/latest/tutorials/query-a-feature-layer-sql/)
+- [Sample Code: GeometryEngine - geodesic buffers](https://developers.arcgis.com/javascript/latest/sample-code/ge-geodesicbuffer/)
+
+## Live Samples
+
+- [Acquire Buffer Distances from a Server-Side Query](https://esri.github.io/developer-support/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html)
+- [Acquire Buffer Distances from a Client-Side Query](https://esri.github.io/developer-support/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html)

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
@@ -10,8 +10,6 @@
 
     <title>Create Buffer Based on Attributes (Client-Side Query)</title>
 
-    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
-
     <script src="https://js.arcgis.com/4.32/"></script>
     <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
     <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+
+    <title>Create Buffer Based on Attributes (Client-Side Query)</title>
+
+    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
+
+    <script src="https://js.arcgis.com/4.32/"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
+    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+    <style>
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script type="module">
+
+      const [Map, FeatureLayer, GraphicsLayer, Graphic, geodesicBufferOperator, reactiveUtils] = await $arcgis.import([
+        "@arcgis/core/Map.js",
+        "@arcgis/core/layers/FeatureLayer.js",
+        "@arcgis/core/layers/GraphicsLayer.js",
+        "@arcgis/core/Graphic.js",
+        "@arcgis/core/geometry/operators/geodesicBufferOperator.js",
+        "@arcgis/core/core/reactiveUtils.js",
+      ])
+
+      const mapElement = document.querySelector("arcgis-map");
+
+      var featureLayer = new FeatureLayer({
+          url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/0",
+          outFields: ["st", "pop2000"],
+      });
+
+      var bufferLayer = new GraphicsLayer();
+      mapElement.addLayers([featureLayer, bufferLayer]);
+
+      var geometries = [];
+      var distances = [];
+
+      var bufferSym = {
+        type: "simple-fill", // autocasts as new SimpleFillSymbol()
+        color: [140, 140, 222, 0.5],
+        outline: {
+          color: [0, 0, 0, 0.5],
+          width: 2,
+        },
+      };
+
+      mapElement.whenLayerView(featureLayer).then(function (layerView) {
+        const handle = reactiveUtils.watch(
+          () => layerView.updating,
+          (value) => {
+            if (!value) {
+              layerView
+                .queryFeatures({
+                  where: "st = 'NC'",
+                  returnGeometry: true,
+                })
+                .then(async function (results) {
+                  results.features.forEach((feature) => {
+                    geometries.push(feature.geometry);
+                    distances.push(feature.attributes.pop2000 / 10000);
+                  });
+
+                  // Verify that isLoaded() returns true before using this module.
+                  if (!geodesicBufferOperator.isLoaded()) {
+                    await geodesicBufferOperator.load();
+                  }
+
+                  var buffer = geodesicBufferOperator.executeMany(
+                    geometries,
+                    distances,
+                    {
+                      unit: "kilometers",
+                      union: true
+                    }
+                  );
+
+                  bufferLayer.add(
+                    new Graphic({
+                      geometry: buffer[0],
+                      symbol: bufferSym,
+                    })
+                  );
+
+                  removeHandle();
+                })
+                .catch(function (error) {
+                  console.error("query failed: ", error);
+                });
+            }
+          }
+        );
+
+        // Remove WatchHandle after query
+        function removeHandle() {
+          handle.remove();
+        }
+      });
+    </script>
+  </head>
+
+  <body>
+    <arcgis-map id="mapView" center="-79.0193, 35.7596" zoom=8 basemap="gray-vector">
+      <arcgis-home position="top-right"></arcgis-home>
+      <arcgis-zoom position="top-right"></arcgis-zoom>
+    </arcgis-map>
+  </body>
+</html>

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+
+    <title>Create Buffer Based on Attributes (Server-Side Query)</title>
+
+    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
+
+    <script src="https://js.arcgis.com/4.32/"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
+    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+    <style>
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script type="module">
+
+      const [Map, FeatureLayer, GraphicsLayer, Graphic, geodesicBufferOperator, reactiveUtils] = await $arcgis.import([
+        "@arcgis/core/Map.js",
+        "@arcgis/core/layers/FeatureLayer.js",
+        "@arcgis/core/layers/GraphicsLayer.js",
+        "@arcgis/core/Graphic.js",
+        "@arcgis/core/geometry/operators/geodesicBufferOperator.js"
+      ])
+
+      const mapElement = document.querySelector("arcgis-map");
+
+      var featureLayer = new FeatureLayer({
+          url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/0",
+      });
+
+      var bufferLayer = new GraphicsLayer();
+      mapElement.addLayers([featureLayer, bufferLayer]);
+
+      var geometries = [];
+      var distances = [];
+
+      var bufferSym = {
+        type: "simple-fill", // autocasts as new SimpleFillSymbol()
+        color: [140, 140, 222, 0.5],
+        outline: {
+          color: [0, 0, 0, 0.5],
+          width: 2,
+        },
+      };
+
+      var query = {
+          outFields: ["pop2000"],
+          returnGeometry: true,
+          where: "st = 'NC'",
+      };
+
+      featureLayer.queryFeatures(query).then(async function (results) {
+        results.features.forEach((feature) => {
+          geometries.push(feature.geometry);
+          distances.push(feature.attributes.pop2000 / 10000);
+        });
+
+        // Verify that isLoaded() returns true before using this module.
+        if (!geodesicBufferOperator.isLoaded()) {
+          await geodesicBufferOperator.load();
+        }
+
+        var buffer = geodesicBufferOperator.executeMany(
+          geometries,
+          distances,
+          {
+            unit: "kilometers",
+            union: true
+          }
+        );
+
+        bufferLayer.add(
+          new Graphic({
+            geometry: buffer[0],
+            symbol: bufferSym,
+          })
+        );
+      });
+    </script>
+  </head>
+
+  <body>
+    <arcgis-map id="mapView" center="-79.0193, 35.7596" zoom=8 basemap="gray-vector">
+      <arcgis-home position="top-right"></arcgis-home>
+      <arcgis-zoom position="top-right"></arcgis-zoom>
+    </arcgis-map>
+  </body>
+</html>

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
@@ -10,8 +10,6 @@
 
     <title>Create Buffer Based on Attributes (Server-Side Query)</title>
 
-    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
-
     <script src="https://js.arcgis.com/4.32/"></script>
     <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
     <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>

--- a/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
+++ b/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
@@ -10,8 +10,6 @@ Find the ArcGIS Online portal item ID for a feature layer. Paste it into the inp
 
 This tool is useful when the service-level drawingInfo is different than the item-level drawingInfo.
 
-### Using geometryService.project()
-
 1. Create a featureLayer with associated portalID
 
 ```javascript

--- a/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
+++ b/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
@@ -1,0 +1,53 @@
+# Get Feature Layer's drawingInfo
+
+## About
+
+This tool allows the user to obtain the drawingInfo of their FeatureLayer.
+
+## How It Works
+
+Find the ArcGIS Online portal item ID for a feature layer. Paste it into the input and select "+ Set layer". The item's drawingInfo will appear under the results.
+
+This tool is useful when the service-level drawingInfo is different than the item-level drawingInfo.
+
+### Using geometryService.project()
+
+1. Create a featureLayer with associated portalID
+
+```javascript
+const mapElement = document.querySelector("arcgis-map");
+var map = mapElement.map;
+...
+  var featureLayer = new FeatureLayer({
+      portalItem: {
+          id: val,
+      },
+  });
+  mapElement.addLayer(featureLayer);
+...
+```
+
+2. Wait for featureLayer class to be created, then obtain the drawingInfo
+
+```javascript
+featureLayer.when(() => {
+...
+    JSON.stringify(
+      featureLayer.toJSON().layerDefinition.drawingInfo
+    )
+...
+});
+```
+
+3. (OPTIONAL) Add API key to grant access to secured ArcGIS Online services
+
+```javascript
+esriConfig.apiKey = "API KEY GOES HERE";
+```
+
+## Related Documentation
+
+- [FeatureLayer](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html)
+
+## Live Samples
+https://esri.github.io/developer-support/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info

--- a/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/index.html
+++ b/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <title>Get Drawing Info Tool</title>
+
+    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
+
+    <script src="https://js.arcgis.com/4.32/"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
+    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+    <style>
+      html,
+      body,
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+
+    <script type="module">
+
+        var inp = document.getElementById("input");
+        var out = document.getElementById("output");
+        var btn = document.getElementById("submitbtn");
+
+        const [FeatureLayer, esriConfig] = await $arcgis.import([
+            "@arcgis/core/layers/FeatureLayer.js",
+            "@arcgis/core/config.js"
+        ])
+
+        // Uncomment if working with an API Key
+        // esriConfig.apiKey = "";
+
+        const mapElement = document.querySelector("arcgis-map");
+        var map = mapElement.map;
+
+        btn.onclick = () => {
+          mapElement.map.removeAll();
+
+          const val = inp.value;
+
+          var featureLayer = new FeatureLayer({
+              portalItem: {
+                  id: val,
+              },
+          });
+          mapElement.addLayer(featureLayer);
+
+          featureLayer.when(() => {
+            return featureLayer.queryExtent();
+          }).then((response) => {
+            mapElement.goTo(response.extent);
+            printResult(featureLayer);
+          })
+
+
+        };
+
+        function printResult(featureLayer) {
+          featureLayer.when(() => {
+            var outstring =
+              '{"drawingInfo":' +
+              JSON.stringify(
+                featureLayer.toJSON().layerDefinition.drawingInfo
+              ) +
+              "}";
+            outstring = outstring.replaceAll(",", ", ");
+            outstring = outstring.replaceAll(":", ": ");
+            out.innerHTML = outstring;
+          });
+        }
+    </script>
+  </head>
+
+  <body>
+    <calcite-shell>
+        <calcite-shell-panel slot="panel-start">
+            <calcite-panel heading="Get Drawing Info Tool">
+                <calcite-block collapsible heading="Enter PortalID" expanded="true">
+                    <calcite-input
+                      placeholder="PORTAL_ID"
+                      id="input"
+                    ></calcite-input>
+                    <br />
+                    <calcite-button icon-start="plus" id="submitbtn">Set Layer</calcite-button>
+                  </calcite-block>
+                  <calcite-block collapsible heading="Results" id="result-block" expanded="true">
+                    <div id="output">No results</div>
+                  </calcite-block>
+            </calcite-panel>
+        </calcite-shell-panel>
+        <arcgis-map id="mapView" basemap="gray-vector">
+            <arcgis-home position="top-right"></arcgis-home>
+            <arcgis-zoom position="top-right"></arcgis-zoom>
+        </arcgis-map>
+    </calcite-shell>
+  </body>
+</html>

--- a/web-js/4.x/buffer-based-on-attributes/README.md
+++ b/web-js/4.x/buffer-based-on-attributes/README.md
@@ -1,5 +1,12 @@
 # Create Buffer Based on Attributes
 
+## RETIREMENT NOTICE
+This sample currently uses a retired version of the ArcGIS Maps SDK for JavaScript (4.17).
+
+There is a new version of this sample (see [here](https://github.com/Esri/developer-support/tree/master/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes)).
+
+If you would like to learn more about retired versions of this product, visit the [ArcGIS Maps SDK for JavaScript Product Life Cycle page](https://support.esri.com/en-us/products/arcgis-maps-sdk-for-javascript/life-cycle). 
+
 ## About
 
 This sample shows how to use an attribute value as the distance when generating buffers.


### PR DESCRIPTION
Created an original sample obtains DrawingInfo from feature layer portal items.

The other 2 sample are modifications of: https://github.com/Esri/developer-support/tree/master/web-js/4.x/buffer-based-on-attributes

These modifications include:
- Migration from version 4.17 to 4.32
- Implementation of [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/get-started-cdn/#module-loading-via-cdn)
- Replacing the deprecated geometryEngine classes with [geometry operators](https://developers.arcgis.com/javascript/latest/spatial-analysis/intro-geometry-operators/)