### PR TITLE
Migrating 2 samples to the latest versions

### DIFF
--- a/calcite-design-system/date-filter/README.md
+++ b/calcite-design-system/date-filter/README.md
@@ -1,0 +1,23 @@
+# Filter with a date range, client-side FeatureLayer
+
+This sample uses the ArcGIS Maps SDK for JavaScript 4.x and Calcite Design System to filter the client-side graphics on the screen using the FeatureLayerView, and the filter property. 
+
+This is an upgraded version of another sample. If you would like to learn more about the JavaScript logic of filtering the layer, please visit [this sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/date-filter). 
+
+## Getting Started
+
+This html file is ready for deployment. This sample uses the [Earthquakes1970](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Earthquakes_Since1970/FeatureServer) feature service from [sampleserver6.arcgisonline.com](https://sampleserver6.arcgisonline.com/arcgis/rest/services).
+
+## Built With
+
+* [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/) - Using version 4.32
+* [Calcite Design System](https://developers.arcgis.com/calcite-design-system/) for the UI components
+
+## Relevant Calcite Design System API
+* [Calcite panel](https://developers.arcgis.com/calcite-design-system/components/panel/)
+* [Calcite label](https://developers.arcgis.com/calcite-design-system/components/label/)
+* [Calcite input date picker](https://developers.arcgis.com/calcite-design-system/components/input-date-picker/)
+* [Calcite button](https://developers.arcgis.com/calcite-design-system/components/button/)
+
+## Live Sample
+* [https://esri.github.io/developer-support/calcite-design-system/date-filter/](https://esri.github.io/developer-support/calcite-design-system/date-filter/)

--- a/calcite-design-system/date-filter/index.html
+++ b/calcite-design-system/date-filter/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <title>Date Filter</title>
+
+    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
+
+    <script src="https://js.arcgis.com/4.32/"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
+    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+    <style>
+      html,
+      body{
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      form {
+        margin: 10px;
+      }
+
+      calcite-panel {
+        height: auto;
+        width: 325px;
+      }
+
+    </style>
+
+    <script type="module">
+
+      const [FeatureLayer] = await $arcgis.import(["@arcgis/core/layers/FeatureLayer.js"]);
+
+      const map = document.querySelector("arcgis-map");
+
+      const serviceUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Earthquakes_Since1970/FeatureServer/0";
+      const dateField = "date_";
+      
+      var featureLayer = new FeatureLayer({
+          url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Earthquakes_Since1970/FeatureServer/0",
+          outFields: ["*"],
+      });
+
+      map.addLayer(featureLayer);
+
+      // the client-side layer
+      let featureLayerView;
+
+      // Save date values when reset
+      let prevStartDate;
+      let prevEndDate;
+
+      const startInput = document.getElementById("startInput");
+      const endInput = document.getElementById("endInput");
+
+      featureLayer.when(() => {
+        const minFullDate = featureLayer.timeInfo.fullTimeExtent.start.toISOString();
+        const maxFullDate = featureLayer.timeInfo.fullTimeExtent.end.toISOString();;
+
+        startInput.min = minFullDate;
+        startInput.max = maxFullDate;
+        prevStartDate = minFullDate;
+        startInput.value = prevStartDate;
+
+        endInput.min = minFullDate;
+        endInput.max = maxFullDate;
+        prevEndDate = maxFullDate;
+        endInput.value = prevEndDate;
+
+        map.whenLayerView(featureLayer)
+          .then((layerView) => {
+            // set up the featureLayerView as the client-side layer
+            featureLayerView = layerView;
+          });
+      })
+
+      // Handle button and panel events
+      const dateForm = document.getElementById("dateForm");
+      const panel = document.getElementById("panel");
+      const resetBtn = document.getElementById("resetBtn");
+
+      resetBtn.onclick = function(){
+        resetLayer()
+      };
+
+      const handleFormSubmit = (evt) => {
+          //filters the layer by date 
+          evt.preventDefault(); // prevent a form submit, we only need the form values
+          const startDate = startInput.value;
+          const endDate = endInput.value;
+
+          if (startDate.length > 0 && endDate.length > 0) {
+            featureLayerView.filter = {
+              where: `${dateField} > DATE '${startDate}' AND ${dateField} < DATE '${endDate}'`
+            }
+
+            prevStartDate = startDate;
+            prevEndDate = endDate;
+          } else {
+            console.log('Please provide a start and end date');
+          }    
+      }
+
+      dateForm.addEventListener('submit', handleFormSubmit);
+
+      // reset the client-side layer by filtering to return all the features
+      const resetLayer = () => {
+        featureLayerView.filter = {
+          where: '1=1'
+        }
+
+        startInput.value = prevStartDate;
+        endInput.value = prevEndDate;
+      }
+    </script>
+  </head>
+
+  <body>
+    <arcgis-map basemap="dark-gray-vector" center="-41.34, 26.274" zoom="3">
+      <arcgis-zoom position="top-left"></arcgis-zoom>
+      <arcgis-home position="top-left"></arcgis-home>
+        <arcgis-placement position="top-right">
+          <calcite-panel heading="Filter by date" id="panel">
+            <form id="dateForm">
+              <calcite-label id="startLabel" for="datePickerForm">
+                Start Date:
+                <calcite-input-date-picker overlay-positioning="fixed" id="startInput"></calcite-input-date-picker>
+              </calcite-label>
+              <calcite-label id="endLabel" for="datePickerForm">
+                End Date:
+                <calcite-input-date-picker overlay-positioning="fixed" id="endInput"></calcite-input-date-picker>
+              </calcite-label>
+              <calcite-button id="resetBtn" icon-end="reset" appearance="outline">Reset</calcite-button>
+              <calcite-button id="submitBtn" type="submit" icon-end="submit">Submit</calcite-button>
+            </form>
+          </calcite-panel>
+        </arcgis-placement>
+    </arcgis-map>
+  </body>
+</html>

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
@@ -11,43 +11,41 @@ Created by Lingtao
 1. Acquire the user's current location using the getCurrentPosition() method.
 
 ```javascript
-      view.when(() => {
-        navigator.geolocation.getCurrentPosition(showPosition);
-      });
+navigator.geolocation.getCurrentPosition(showPosition);
 ```
 
 2. Create a point Graphic based on the result from getCurrentPosition().
 
 ```javascript
-        var pointGraphic = new Graphic({
-          geometry: {
-            type: "point",
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude
-          }
-        });
+var pointGraphic = new Graphic({
+  geometry: {
+    type: "point",
+    latitude: position.coords.latitude,
+    longitude: position.coords.longitude
+  }
+});
 ```
 
 3. Create a FeatureLayer based on the point Graphic if you need to label the location point.
 
 ```javascript
-        var layer = new FeatureLayer({
-          source: [pointGraphic],
-          fields: [{
-            name: "ObjectID",
-            alias: "ObjectID",
-            type: "oid"
-          }],
-          objectIdField: "ObjectID",
-          title: "Located Point",
-          popupEnabled: false,
-          labelingInfo: {
-            labelExpressionInfo: {
-              expression: "'You Are Here'"
-            },
-            labelPlacement: "below-center"
-          }
-        });
+var layer = new FeatureLayer({
+  source: [pointGraphic],
+  fields: [{
+    name: "ObjectID",
+    alias: "ObjectID",
+    type: "oid"
+  }],
+  objectIdField: "ObjectID",
+  title: "Located Point",
+  popupEnabled: false,
+  labelingInfo: {
+    labelExpressionInfo: {
+      expression: "'You Are Here'"
+    },
+    labelPlacement: "below-center"
+  }
+});
 ```
 
 ## Related Documentation

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
@@ -1,13 +1,10 @@
 # Create a FeatureLayer Based on Current Location
 
-## RETIREMENT NOTICE
-This sample currently uses a retired version of the ArcGIS Maps SDK for JavaScript (4.16).
-
-If you would like to learn more about retired versions of this product, visit the [ArcGIS Maps SDK for JavaScript Product Life Cycle page](https://support.esri.com/en-us/products/arcgis-maps-sdk-for-javascript/life-cycle). 
-
 ## About
 
 The ArcGIS API for JavaScript 4.x provides an out-of-the-box [Locate widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html) that animates the [View](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-View.html) to the user's current location. This sample shows how to display the user's current location on the map using the Geolocation API and FeatureLayer instead of the Locate widget.  
+
+Created by Lingtao
 
 ## How It Works
 
@@ -61,7 +58,7 @@ The ArcGIS API for JavaScript 4.x provides an out-of-the-box [Locate widget](htt
 - [FeatureLayer](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html)
 - [Graphic](https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html)
 - [Locate Widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html)
-- [Sample Code: Locate Widget](https://developers.arcgis.com/javascript/latest/sample-code/widgets-locate/index.html)
+- [Sample Code: Locate Widget](https://developers.arcgis.com/javascript/latest/sample-code/widgets-locate/)
 
 
-## [Live Sample](https://esri.github.io/developer-support/web-js/4.x/current-location-FeatureLayer/)
+## [Live Sample](https://esri.github.io/developer-support/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/)

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
+  <title>Create a FeatureLayer Based on Current Location | ArcGIS API for JavaScript 4.32</title>
+
+  <style>
+    html,
+    body,
+    #viewDiv {
+      padding: 0;
+      margin: 0;
+      height: 100%;
+      width: 100%;
+    }
+  </style>
+  
+  <script src="https://js.arcgis.com/4.32/"></script>
+  <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
+  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+
+  <script type="module">
+    const [Map, FeatureLayer, Graphic, MapView] = await $arcgis.import([
+      "@arcgis/core/Map.js",
+      "@arcgis/core/layers/FeatureLayer.js",
+      "@arcgis/core/Graphic.js",
+      "@arcgis/core/views/MapView.js"
+    ])
+
+    const mapElement = document.querySelector("arcgis-map");
+
+    function showPosition(position) {
+      var pointGraphic = new Graphic({
+        geometry: {
+          type: "point",
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude
+        }
+      });
+
+      var layer = new FeatureLayer({
+        source: [pointGraphic],
+        fields: [{
+          name: "ObjectID",
+          alias: "ObjectID",
+          type: "oid"
+        }],
+        objectIdField: "ObjectID",
+        title: "Located Point",
+        popupEnabled: false,
+        labelingInfo: {
+          labelExpressionInfo: {
+            expression: "'You Are Here'"
+          },
+          labelPlacement: "below-center"
+        }
+      });
+      mapElement.addLayer(layer);
+    }
+
+    view.when(() => {
+      navigator.geolocation.getCurrentPosition(showPosition);
+    });
+  </script>
+</head>
+
+<body>
+  <arcgis-map id="mapView" center="-56.049, 38.485, 78" zoom=3 basemap="gray-vector">
+      <arcgis-home position="top-right"></arcgis-home>
+      <arcgis-zoom position="top-right"></arcgis-zoom>
+      <arcgis-legend position="bottom-right"></arcgis-legend>
+    </arcgis-map>
+</body>
+
+</html>

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
@@ -9,8 +9,7 @@
 
   <style>
     html,
-    body,
-    #viewDiv {
+    body{
       padding: 0;
       margin: 0;
       height: 100%;
@@ -58,12 +57,11 @@
           labelPlacement: "below-center"
         }
       });
+      
       mapElement.addLayer(layer);
     }
 
-    view.when(() => {
-      navigator.geolocation.getCurrentPosition(showPosition);
-    });
+    navigator.geolocation.getCurrentPosition(showPosition);
   </script>
 </head>
 

--- a/web-js/4.x/add-attachments-with-42/README.md
+++ b/web-js/4.x/add-attachments-with-42/README.md
@@ -1,5 +1,14 @@
 # Add Attachments To FeatureService with JavaScript 4.2
 
+## RETIREMENT NOTICE
+This sample currently uses a retired version of the ArcGIS Maps SDK for JavaScript (4.2).
+
+In the latest version of the ArcGIS Maps SDK for JavaScript, it is possible to achieve this functionality using the [Editor](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Editor.html) widget.
+
+[Live Sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-editor-basic/)
+
+If you would like to learn more about retired versions of this product, visit the [ArcGIS Maps SDK for JavaScript Product Life Cycle page](https://support.esri.com/en-us/products/arcgis-maps-sdk-for-javascript/life-cycle). 
+
 ## About
 FeatureServices can be configured to allow files to be attached to individual features in the service. In the 3.x JavaScript API methods to retrieve, add and delete attachments were provided as part of the FeatureLayer class. Additionally widgets such as the attachment and attribute inspector allowed attachments to be viewed and edited. In the 4.2 API no widgets or methods have been provided to work with attachments. However it is still possible to directly query and edit attachments using the ArcGIS REST API. This sample shows how to work with attachments within a 4.2 application.
 

--- a/web-js/4.x/date-filter/README.md
+++ b/web-js/4.x/date-filter/README.md
@@ -2,6 +2,8 @@
 
 This project uses the ArcGIS JavaScript API 4.x to filter the client-side graphics on the screen using the FeatureLayerView, and the filter property. 
 
+There is a new version of this sample (see [here](https://github.com/Esri/developer-support/tree/master/calcite-design-system/date-filter)).
+
 <img src="date-filter.png" width="600"/>
 
 ## Getting Started


### PR DESCRIPTION
Migrated the following samples:
- https://github.com/Esri/developer-support/tree/master/web-js/4.x/current-location-FeatureLayer
- https://github.com/Esri/developer-support/tree/master/web-js/4.x/date-filter

Migration might include:
- Upgrade to ArcGIS Maps SDK for JavaScript 4.32
- Use of Map Components
- Maps SDK modules via the global function $arcgis.import() : https://developers.arcgis.com/javascript/latest/get-started-cdn/#module-loading-via-cdn
- Using Calcite Design System components

Created retirement notice in README for a sample that has existing functionalities in the latest version: https://github.com/Esri/developer-support/tree/master/web-js/4.x/add-attachments-with-42