### PR TITLE
Migrate JS samples to Maps SDK 5.0

### DIFF
--- a/calcite-design-system/date-filter/README.md
+++ b/calcite-design-system/date-filter/README.md
@@ -1,6 +1,6 @@
 # Filter with a date range, client-side FeatureLayer
 
-This sample uses the ArcGIS Maps SDK for JavaScript 4.x and Calcite Design System to filter the client-side graphics on the screen using the FeatureLayerView, and the filter property. 
+This sample uses the ArcGIS Maps SDK for JavaScript 5.0 to filter the client-side graphics on the screen using the FeatureLayerView, and the filter property. 
 
 This is an upgraded version of another sample. If you would like to learn more about the JavaScript logic of filtering the layer, please visit [this sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/date-filter). 
 
@@ -10,8 +10,7 @@ This html file is ready for deployment. This sample uses the [Earthquakes1970](h
 
 ## Built With
 
-* [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/) - Using version 4.32
-* [Calcite Design System](https://developers.arcgis.com/calcite-design-system/) for the UI components
+* [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/) - Using version 5.0
 
 ## Relevant Calcite Design System API
 * [Calcite panel](https://developers.arcgis.com/calcite-design-system/components/panel/)

--- a/calcite-design-system/date-filter/index.html
+++ b/calcite-design-system/date-filter/index.html
@@ -8,11 +8,7 @@
     />
     <title>Date Filter</title>
 
-    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
-
-    <script src="https://js.arcgis.com/4.32/"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
     <style>
       html,
@@ -48,7 +44,9 @@
           outFields: ["*"],
       });
 
-      map.addLayer(featureLayer);
+      await map.viewOnReady();
+
+      map.map.add(featureLayer);
 
       // the client-side layer
       let featureLayerView;
@@ -124,9 +122,9 @@
 
   <body>
     <arcgis-map basemap="dark-gray-vector" center="-41.34, 26.274" zoom="3">
-      <arcgis-zoom position="top-left"></arcgis-zoom>
-      <arcgis-home position="top-left"></arcgis-home>
-        <arcgis-placement position="top-right">
+      <arcgis-zoom slot="top-left"></arcgis-zoom>
+      <arcgis-home slot="top-left"></arcgis-home>
+        <arcgis-placement slot="top-right">
           <calcite-panel heading="Filter by date" id="panel">
             <form id="dateForm">
               <calcite-label id="startLabel" for="datePickerForm">

--- a/calcite-design-system/dynamic-table/index.html
+++ b/calcite-design-system/dynamic-table/index.html
@@ -2,8 +2,7 @@
 <html>
 	<head>
 		<title>Dynamic Table with Calcite</title>
-		<script type="module" src="https://js.arcgis.com/calcite-components/2.4.0/calcite.esm.js"></script>
-		<link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.4.0/calcite.css"/>
+		<script type="module" src="https://js.arcgis.com/calcite-components/5.0"></script>
         <link rel="stylesheet" type="text/css" href="main.css"/>
         <script src="functions.js"></script>
     </head>

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/README.MD
@@ -5,9 +5,9 @@
 This sample shows how to use an attribute value as the distance when generating buffers.
 
 This sample is a modification of an [older sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/buffer-based-on-attributes). These modifications include:
-- Migration from version 4.17 to 4.32
+- Migration from version 4.17 to 5.0
 - Implementation of [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
-- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/4.32/#module-loading-via-cdn)
+- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/v4-32/#module-loading-via-cdn)
 - Replacing the deprecated geometryEngine classes with [geometry operators](https://developers.arcgis.com/javascript/latest/spatial-analysis/intro-geometry-operators/)
 
 ## How It Works

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_client_side.html
@@ -10,9 +10,7 @@
 
     <title>Create Buffer Based on Attributes (Client-Side Query)</title>
 
-    <script src="https://js.arcgis.com/4.32/"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
     <style>
       html,
@@ -42,8 +40,10 @@
           outFields: ["st", "pop2000"],
       });
 
+      await mapElement.viewOnReady();
+
       var bufferLayer = new GraphicsLayer();
-      mapElement.addLayers([featureLayer, bufferLayer]);
+      mapElement.map.addMany([featureLayer, bufferLayer]);
 
       var geometries = [];
       var distances = [];
@@ -113,8 +113,8 @@
 
   <body>
     <arcgis-map id="mapView" center="-79.0193, 35.7596" zoom=8 basemap="gray-vector">
-      <arcgis-home position="top-right"></arcgis-home>
-      <arcgis-zoom position="top-right"></arcgis-zoom>
+      <arcgis-home slot="top-right"></arcgis-home>
+      <arcgis-zoom slot="top-right"></arcgis-zoom>
     </arcgis-map>
   </body>
 </html>

--- a/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
+++ b/maps-sdk/javascript-maps-sdk/buffer-based-on-attributes/query_attributes_from_server_side.html
@@ -10,10 +10,7 @@
 
     <title>Create Buffer Based on Attributes (Server-Side Query)</title>
 
-    <script src="https://js.arcgis.com/4.32/"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
-
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
     <style>
       html,
       body {
@@ -41,7 +38,9 @@
       });
 
       var bufferLayer = new GraphicsLayer();
-      mapElement.addLayers([featureLayer, bufferLayer]);
+
+      await mapElement.viewOnReady();
+      mapElement.map.addMany([featureLayer, bufferLayer]);
 
       var geometries = [];
       var distances = [];
@@ -93,8 +92,8 @@
 
   <body>
     <arcgis-map id="mapView" center="-79.0193, 35.7596" zoom=8 basemap="gray-vector">
-      <arcgis-home position="top-right"></arcgis-home>
-      <arcgis-zoom position="top-right"></arcgis-zoom>
+      <arcgis-home slot="top-right"></arcgis-home>
+      <arcgis-zoom slot="top-right"></arcgis-zoom>
     </arcgis-map>
   </body>
 </html>

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/README.md
@@ -2,9 +2,7 @@
 
 ## About
 
-The ArcGIS API for JavaScript 4.x provides an out-of-the-box [Locate widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html) that animates the [View](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-View.html) to the user's current location. This sample shows how to display the user's current location on the map using the Geolocation API and FeatureLayer instead of the Locate widget.  
-
-Created by Lingtao
+The ArcGIS Maps SDK for JavaScript provides an out-of-the-box [Locate component](https://developers.arcgis.com/javascript/latest/references/map-components/components/arcgis-locate/) that animates the [View](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-View.html) to the user's current location. This sample shows how to display the user's current location on the map using the Geolocation API and FeatureLayer instead of the Locate widget.  
 
 ## How It Works
 
@@ -55,8 +53,8 @@ var layer = new FeatureLayer({
 - [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API)
 - [FeatureLayer](https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html)
 - [Graphic](https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html)
-- [Locate Widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html)
-- [Sample Code: Locate Widget](https://developers.arcgis.com/javascript/latest/sample-code/widgets-locate/)
+- [Locate Component](https://developers.arcgis.com/javascript/latest/references/map-components/components/arcgis-locate/)
+- [Sample Code: Locate Component](https://developers.arcgis.com/javascript/latest/sample-code/locate/)
 
 
 ## [Live Sample](https://esri.github.io/developer-support/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/)

--- a/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
+++ b/maps-sdk/javascript-maps-sdk/current-location-FeatureLayer/index.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
-  <title>Create a FeatureLayer Based on Current Location | ArcGIS API for JavaScript 4.32</title>
+  <title>Create a FeatureLayer Based on Current Location</title>
 
   <style>
     html,
@@ -17,9 +17,7 @@
     }
   </style>
   
-  <script src="https://js.arcgis.com/4.32/"></script>
-  <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
   <script type="module">
     const [Map, FeatureLayer, Graphic, MapView] = await $arcgis.import([
@@ -30,6 +28,8 @@
     ])
 
     const mapElement = document.querySelector("arcgis-map");
+
+    await mapElement.viewOnReady();
 
     function showPosition(position) {
       var pointGraphic = new Graphic({
@@ -58,7 +58,7 @@
         }
       });
       
-      mapElement.addLayer(layer);
+      mapElement.map.add(layer);
     }
 
     navigator.geolocation.getCurrentPosition(showPosition);
@@ -67,9 +67,9 @@
 
 <body>
   <arcgis-map id="mapView" center="-56.049, 38.485, 78" zoom=3 basemap="gray-vector">
-      <arcgis-home position="top-right"></arcgis-home>
-      <arcgis-zoom position="top-right"></arcgis-zoom>
-      <arcgis-legend position="bottom-right"></arcgis-legend>
+      <arcgis-home slot="top-right"></arcgis-home>
+      <arcgis-zoom slot="top-right"></arcgis-zoom>
+      <arcgis-legend slot="bottom-right"></arcgis-legend>
     </arcgis-map>
 </body>
 

--- a/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
+++ b/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/README.md
@@ -14,6 +14,7 @@ This tool is useful when the service-level drawingInfo is different than the ite
 
 ```javascript
 const mapElement = document.querySelector("arcgis-map");
+await mapElement.viewOnReady();
 var map = mapElement.map;
 ...
   var featureLayer = new FeatureLayer({
@@ -21,7 +22,7 @@ var map = mapElement.map;
           id: val,
       },
   });
-  mapElement.addLayer(featureLayer);
+  mapElement.map.add(featureLayer);
 ...
 ```
 

--- a/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/index.html
+++ b/maps-sdk/javascript-maps-sdk/get-featurelayer-drawing-info/index.html
@@ -8,11 +8,7 @@
     />
     <title>Get Drawing Info Tool</title>
 
-    <script type="module" src="https://js.arcgis.com/calcite-components/3.1.0/calcite.esm.js"></script>
-
-    <script src="https://js.arcgis.com/4.32/"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/light/main.css" />
-    <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
     <style>
       html,
@@ -40,6 +36,9 @@
         // esriConfig.apiKey = "";
 
         const mapElement = document.querySelector("arcgis-map");
+
+        await mapElement.viewOnReady();
+
         var map = mapElement.map;
 
         btn.onclick = () => {
@@ -52,7 +51,7 @@
                   id: val,
               },
           });
-          mapElement.addLayer(featureLayer);
+          mapElement.map.add(featureLayer);
 
           featureLayer.when(() => {
             return featureLayer.queryExtent();
@@ -84,7 +83,7 @@
     <calcite-shell>
         <calcite-shell-panel slot="panel-start">
             <calcite-panel heading="Get Drawing Info Tool">
-                <calcite-block collapsible heading="Enter PortalID" expanded="true">
+                <calcite-block collapsible heading="Enter AGOL PortalID" expanded="true">
                     <calcite-input
                       placeholder="PORTAL_ID"
                       id="input"
@@ -98,8 +97,8 @@
             </calcite-panel>
         </calcite-shell-panel>
         <arcgis-map id="mapView" basemap="gray-vector">
-            <arcgis-home position="top-right"></arcgis-home>
-            <arcgis-zoom position="top-right"></arcgis-zoom>
+            <arcgis-home slot="top-right"></arcgis-home>
+            <arcgis-zoom slot="top-right"></arcgis-zoom>
         </arcgis-map>
     </calcite-shell>
   </body>

--- a/maps-sdk/javascript-maps-sdk/layer-list-with-attribute-table-toggle/README.md
+++ b/maps-sdk/javascript-maps-sdk/layer-list-with-attribute-table-toggle/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This sample shows how to add an [ActionToggle](https://developers.arcgis.com/javascript/latest/api-reference/esri-support-actions-ActionToggle.html) to the [Layerlist widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-LayerList.html) that toggles on and off the attribute table of layers.
+This sample shows how to add an [ActionToggle](https://developers.arcgis.com/javascript/latest/api-reference/esri-support-actions-ActionToggle.html) to the [Layerlist component](https://developers.arcgis.com/javascript/latest/references/map-components/arcgis-layer-list/) that toggles on and off the attribute table of layers.
 
 To use this sample, open the Layer List widget located at the top right of the map. You can toggle the attribute table of each layer by selecting the '...' option and selecting 'Show Table'.
 

--- a/maps-sdk/javascript-maps-sdk/layer-list-with-attribute-table-toggle/index.html
+++ b/maps-sdk/javascript-maps-sdk/layer-list-with-attribute-table-toggle/index.html
@@ -30,9 +30,7 @@
     }
   </style>
   
-  <script src="https://js.arcgis.com/4.34/"></script>
-  <script type="module" src="https://js.arcgis.com/calcite-components/3.3.3/calcite.esm.js"></script>
-  <script type="module" src="https://js.arcgis.com/4.34/map-components/"></script>
+  <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
   <script type="module">
     const [Map, Collection, FeatureLayer, ActionButton, ActionToggle] = await $arcgis.import([
@@ -176,8 +174,7 @@
             To use this sample, open the Layer List widget located at the top right of the map. You can toggle the attribute table of each layer by selecting the '...' option and selecting 'Show Table'.
             <br><br>
             <i>Current versions:</i><br>
-            <i>ArcGIS Maps SDK for JavaScript version 4.34</i><br>
-            <i>Calcite Design System version 3.3.3</i>
+            <i>ArcGIS Maps SDK for JavaScript version 5.0</i><br>
         </p>
       </arcgis-expand>
 

--- a/maps-sdk/javascript-maps-sdk/load-basic-map-using-amd-require/README.md
+++ b/maps-sdk/javascript-maps-sdk/load-basic-map-using-amd-require/README.md
@@ -3,8 +3,7 @@
 ## About
 
 Traditionally, require has been the go-to method for asynchronous module loading, adhering to the AMD (Asynchronous Module Definition) specification. Starting in ArcGIS Maps SDK for JavaScript version 4.32, a new way of loading AMD modules via CDN was introduced. For more information on this new approach, please refer to the following resources:
-- [Introduction in 4.32](https://developers.arcgis.com/javascript/latest/4.32/#module-loading-via-cdn)
-- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/get-started/#cdn)
+- [Introduction in 4.32](https://developers.arcgis.com/javascript/latest/v4-32/#module-loading-via-cdn)
 
 This sample serves as a template reflecting the structure of applications created in earlier versions. However, it is not the recommended approach for current development. The JavaScript ecosystem is continually evolving, and this feature may become obsolete in future SDK versions. It is advisable to keep your application up-to-date. If you would like to learn more about retired versions of this product, visit the [ArcGIS Maps SDK for JavaScript Product Life Cycle page](https://support.esri.com/en-us/products/arcgis-maps-sdk-for-javascript/life-cycle). 
 

--- a/maps-sdk/javascript-maps-sdk/load-basic-map-using-amd-require/index.html
+++ b/maps-sdk/javascript-maps-sdk/load-basic-map-using-amd-require/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <title>Intro to MapView - Create a 2D map | Sample | ArcGIS Maps SDK for JavaScript 4.33</title>
+    <title>Intro to MapView - Create a 2D map | Sample | ArcGIS Maps SDK for JavaScript 4.31</title>
     <style>
       html,
       body,

--- a/maps-sdk/javascript-maps-sdk/map-components-view-toggle/index.html
+++ b/maps-sdk/javascript-maps-sdk/map-components-view-toggle/index.html
@@ -3,16 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
-  <title>Map Components</title>
+  <title>Toggle between Map and Scene Components</title>
 
-  <!-- Load required JS API stylesheets -->
-  <link rel="stylesheet" href="https://js.arcgis.com/4.32/esri/themes/dark/main.css" />
-
-  <!-- Load the ArcGIS JS API -->
-  <script src="https://js.arcgis.com/4.32"></script>
-
-  <!-- Load map components -->
-  <script type="module" src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"></script>
+  <script type="module" src="https://js.arcgis.com/5.0/"></script>
 
   <style>
     /* Note: these CSS settings cause the map to fill the browser window */

--- a/maps-sdk/javascript-maps-sdk/open-popups-with-hittest/index.html
+++ b/maps-sdk/javascript-maps-sdk/open-popups-with-hittest/index.html
@@ -8,7 +8,7 @@
     />
 
     <title>
-      Open Cluster popups with HitTest - 4.33
+      Open Cluster popups with HitTest
     </title>
 
     <style>
@@ -19,31 +19,14 @@
       }
     </style>
 
-    <!-- Load Calcite components from CDN -->
-    <script
-      type="module"
-      src="https://js.arcgis.com/calcite-components/3.2.1/calcite.esm.js"
-    ></script>
-
-    <!-- Load the ArcGIS Maps SDK for JavaScript from CDN -->
-    <link
-      rel="stylesheet"
-      href="https://js.arcgis.com/4.33/esri/themes/light/main.css"
-    />
-    <script src="https://js.arcgis.com/4.33/"></script>
-
-    <!-- Load Map components from CDN-->
-    <script
-      type="module"
-      src="https://js.arcgis.com/4.33/map-components/"
-    ></script>
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
   </head>
 
   <body>
     <arcgis-map basemap="" center="-122.4194,37.7749" zoom="12">
-      <arcgis-zoom position="top-left"></arcgis-zoom>
-      <arcgis-home position="top-left"></arcgis-home>
-      <arcgis-placement position="bottom-left">
+      <arcgis-zoom slot="top-left"></arcgis-zoom>
+      <arcgis-home slot="top-left"></arcgis-home>
+      <arcgis-placement slot="bottom-left">
         <div id="infoDiv">
           <arcgis-layer-list></arcgis-layer-list>
           <calcite-button id="cluster" secondary width="full">Disable Clustering</calcite-button>
@@ -139,6 +122,7 @@
 
       // get the arcgis-map component element
       const viewElement = document.querySelector("arcgis-map");
+
       viewElement.map = new Map({
         basemap: "gray-vector",
         layers: [layer, layerNoCluster]

--- a/maps-sdk/javascript-maps-sdk/show-loading-icon/README.md
+++ b/maps-sdk/javascript-maps-sdk/show-loading-icon/README.md
@@ -5,9 +5,9 @@
 For layers with a large number of features and details, sometimes it might take a bit while for them to be fully drawn on the view. This sample shows how to display a loading icon to indicate whether the view is updating. 
 
 This sample is a modification of an [older sample](https://github.com/Esri/developer-support/tree/master/web-js/4.x/show-loading-icon). These modifications include:
-- Migration from version 4.16 to 4.32
+- Migration from version 4.16 to 5.0
 - Implementation of [Map components](https://developers.arcgis.com/javascript/latest/references/map-components/)
-- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/4.32/#module-loading-via-cdn)
+- [Module loading via CDN](https://developers.arcgis.com/javascript/latest/v4-32/#module-loading-via-cdn)
 - Using [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 
 ## How It Works

--- a/maps-sdk/javascript-maps-sdk/show-loading-icon/index.html
+++ b/maps-sdk/javascript-maps-sdk/show-loading-icon/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <title>Intro to map components - Create a 2D map | Sample | ArcGIS Maps SDK for JavaScript 4.33</title>
+    <title>Show loading Icon</title>
 
     <style>
       html,
@@ -15,15 +15,8 @@
         height: 100vh;
       }
     </style>
-    <!-- Load Calcite components from CDN -->
-    <script type="module" src=https://js.arcgis.com/calcite-components/3.3.3/calcite.esm.js></script>
-
-    <!-- Load the ArcGIS Maps SDK for JavaScript from CDN -->
-    <link rel="stylesheet" href="https://js.arcgis.com/4.33/esri/themes/light/main.css" />
-    <script src="https://js.arcgis.com/4.33/"></script>
-
-    <!-- Load Map components from CDN-->
-    <script type="module" src="https://js.arcgis.com/4.33/map-components/"></script>
+    
+    <script type="module" src="https://js.arcgis.com/5.0/"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Updated the following samples to use ArcGIS Maps SDK for JavaScript 5.0:
- Create Buffer Based on Attributes
- Create a FeatureLayer Based on Current Location
- Get Feature Layer's drawingInfo
- LayerList with Attribute Table Toggle
- Map  to Scene Components View Toggle
- Open Popups using HitTest
- Show loading icon
- Date Filter
- Dynamic Table with Calcite